### PR TITLE
Verbose errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Navigate to the LineCounter directory and build with `make`
 
   `-d` Output all directories visited and their subtotal
 
+  `e` Output any errors encountered in opening files or directories. `-f` and or `-d` must be specified.
+
   `-b` Recursively count through subdirectories
 
   `-s` Output the subtotals of each specified extension

--- a/src/count.c
+++ b/src/count.c
@@ -81,7 +81,7 @@ int countDirectory(char* path, struct FlagContainer f, int* extension_subtotals)
 
     if(d == NULL) {
 
-        if(f.verbose_dir) {
+        if(f.verbose_dir & f.verbose_errors) {
 
             printf("Cannot open directory '%s'\n", path);
 
@@ -176,7 +176,7 @@ int countFile(char* path, struct FlagContainer f, int* extension_subtotals) {
 
     if((fp = fopen(path, "r")) == NULL) {
 
-        if(f.verbose_files) {
+        if(f.verbose_files && f.verbose_errors) {
 
             printf("Cannot open file '%s'\n", path);
 

--- a/src/flags.c
+++ b/src/flags.c
@@ -10,12 +10,13 @@ void setFlags(int argc, char** argv, struct FlagContainer* f) {
 
     f->verbose_files = false;
     f->verbose_dir = false;
+    f->verbose_errors = false;
     f->branch = false;
     f->subtotals = false;
 
     f->extension_count = 0;
 
-    while ((c = getopt(argc, argv, ":fdbs")) != -1) {
+    while ((c = getopt(argc, argv, ":fdebs")) != -1) {
 
         switch(c) {
 
@@ -28,6 +29,9 @@ void setFlags(int argc, char** argv, struct FlagContainer* f) {
             case 'd':
                 f->verbose_dir = true;
                 break;
+
+            case 'e':
+                f->verbose_errors = true;
 
             case 'b':
                 f->branch = true;

--- a/src/flags.h
+++ b/src/flags.h
@@ -5,16 +5,18 @@
 #include <string.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdint.h>
 
 #define EXTENSION_MAX_LENGTH 8
 #define MAX_EXTENSIONS 64
 
 struct FlagContainer{
 
-    char verbose_files   : 1;
-    char verbose_dir     : 1;
-    char branch          : 1;
-    char subtotals       : 1;
+    uint8_t verbose_files   : 1;
+    uint8_t verbose_dir     : 1;
+    uint8_t verbose_errors  : 1;
+    uint8_t branch          : 1;
+    uint8_t subtotals       : 1;
 
     char extensions[MAX_EXTENSIONS][EXTENSION_MAX_LENGTH];
 


### PR DESCRIPTION
The user can now use the `-e` flag to output errors generated when attempting to open a file or directory.